### PR TITLE
Don't merge all params before validating

### DIFF
--- a/lib/committee/schema_validator/open_api_3/request_validator.rb
+++ b/lib/committee/schema_validator/open_api_3/request_validator.rb
@@ -11,11 +11,11 @@ module Committee
           @validator_option = validator_option
         end
 
-        def call(request, params, headers)
+        def call(request, path_params, query_params, body_params, headers)
           content_type = ::Committee::SchemaValidator.request_media_type(request)
           check_content_type(request, content_type) if @validator_option.check_content_type
 
-          @operation_object.validate_request_params(params, headers, @validator_option)
+          @operation_object.validate_request_params(path_params, query_params, body_params, headers, @validator_option)
         end
 
         private

--- a/test/data/openapi3/normal.yaml
+++ b/test/data/openapi3/normal.yaml
@@ -6,6 +6,26 @@ info:
 servers:
 - url: https://github.com/interagent/committee/
 paths:
+  /additional_properties:
+    post:
+      description: post additional_properties
+      parameters:
+        - name: first_name
+          in: query
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                last_name:
+                  type: string
+              required:
+                - last_name
+              additionalProperties: false
   /csv:
     get:
       description: get csv
@@ -609,7 +629,7 @@ paths:
         '200':
           $ref: '#/components/responses/header_integer_required'
 
-  /get_endpoint_with_requered_parameter:
+  /get_endpoint_with_required_parameter:
     get:
       description: get body test
       parameters:

--- a/test/middleware/request_validation_open_api_3_test.rb
+++ b/test/middleware/request_validation_open_api_3_test.rb
@@ -49,7 +49,7 @@ describe Committee::Middleware::RequestValidation do
     params = { "datetime_string" => "2016-04-01T16:00:00.000+09:00" }
 
     check_parameter = lambda { |env|
-      assert_equal nil, env['committee.query_hash']
+      assert_nil env['committee.query_hash']
       assert_equal DateTime, env['rack.request.query_hash']["datetime_string"].class
       [200, {}, []]
     }
@@ -65,7 +65,7 @@ describe Committee::Middleware::RequestValidation do
 
     @app = new_rack_app(schema: open_api_3_schema, allow_get_body: true)
 
-    get "/get_endpoint_with_requered_parameter", { no_problem: true }, { input: params.to_json }
+    get "/get_endpoint_with_required_parameter", { no_problem: true }, { input: params.to_json }
     assert_equal 200, last_response.status
   end
 
@@ -74,7 +74,7 @@ describe Committee::Middleware::RequestValidation do
 
     @app = new_rack_app(schema: open_api_3_schema, allow_get_body: false)
 
-    get "/get_endpoint_with_requered_parameter", { no_problem: true }, { input: params.to_json }
+    get "/get_endpoint_with_required_parameter", { no_problem: true }, { input: params.to_json }
     assert_equal 400, last_response.status
   end
 
@@ -412,12 +412,12 @@ describe Committee::Middleware::RequestValidation do
     get "/coerce_path_params/1"
   end
 
-  it "corce string and save path hash" do
+  it "coerce string and save path hash" do
     @app = new_rack_app_with_lambda(lambda do |env|
-      assert_equal env['committee.params']['integer'], 21
-      assert_equal env['committee.params'][:integer], 21
-      assert_equal env['committee.path_hash']['integer'], 21
-      assert_equal env['committee.path_hash'][:integer], 21
+      assert_equal 21, env['committee.params']['integer']
+      assert_equal 21, env['committee.params'][:integer]
+      assert_equal 21, env['committee.path_hash']['integer']
+      assert_equal 21, env['committee.path_hash'][:integer]
       [204, {}, []]
     end, schema: open_api_3_schema)
 
@@ -426,12 +426,12 @@ describe Committee::Middleware::RequestValidation do
     assert_equal 204, last_response.status
   end
 
-  it "corce string and save request body hash" do
+  it "coerce string and save request body hash" do
     @app = new_rack_app_with_lambda(lambda do |env|
-      assert_equal env['committee.params']['integer'], 21 # use path parameter
-      assert_equal env['committee.params'][:integer], 21
-      assert_equal env['committee.request_body_hash']['integer'], 42
-      assert_equal env['committee.request_body_hash'][:integer], 42
+      assert_equal 21, env['committee.params']['integer'] # path parameter has precedence
+      assert_equal 21, env['committee.params'][:integer]
+      assert_equal 42, env['committee.request_body_hash']['integer']
+      assert_equal 42, env['committee.request_body_hash'][:integer]
       [204, {}, []]
     end, schema: open_api_3_schema)
 
@@ -444,11 +444,10 @@ describe Committee::Middleware::RequestValidation do
 
   it "unpacker test" do
     @app = new_rack_app_with_lambda(lambda do |env|
-      assert_equal env['committee.params']['integer'], 42
-      assert_equal env['committee.params'][:integer], 42
-      # overwrite by request body...
-      assert_equal env['rack.request.query_hash']['integer'], 42
-      # assert_equal env['rack.request.query_hash'][:integer], 42
+      assert_equal '21', env['committee.params']['integer'] # query parameter has precedence
+      assert_equal '21', env['committee.params'][:integer]
+      assert_equal '21', env['rack.request.query_hash']['integer']
+      assert_equal 42, env['committee.request_body_hash']['integer']
       [204, {}, []]
     end, schema: open_api_3_schema, raise: true)
 

--- a/test/middleware/request_validation_test.rb
+++ b/test/middleware/request_validation_test.rb
@@ -435,7 +435,7 @@ describe Committee::Middleware::RequestValidation do
     assert_equal 200, last_response.status
   end
 
-  it "corce form params" do
+  it "coerce form params" do
     check_parameter = lambda { |env|
       assert_equal 3, env['committee.params']['age']
       assert_equal 3, env['committee.request_body_hash']['age']

--- a/test/schema_validator/open_api_3/operation_wrapper_test.rb
+++ b/test/schema_validator/open_api_3/operation_wrapper_test.rb
@@ -32,12 +32,15 @@ describe Committee::SchemaValidator::OpenAPI3::OperationWrapper do
     ]
 
     it 'correct data' do
-      operation_object.validate_request_params(SCHEMA_PROPERTIES_PAIR.to_h, HEADER, @validator_option)
+      operation_object.validate_request_params({}, {}, SCHEMA_PROPERTIES_PAIR.to_h, HEADER, @validator_option)
       assert true
     end
 
     it 'correct object data' do
-      operation_object.validate_request_params({
+      operation_object.validate_request_params(
+                                  {},
+                                  {},
+                                  {
                                      "object_1" =>
                                          {
                                              "string_1" => nil,
@@ -54,7 +57,7 @@ describe Committee::SchemaValidator::OpenAPI3::OperationWrapper do
 
     it 'invalid params' do
       e = assert_raises(Committee::InvalidRequest) {
-        operation_object.validate_request_params({"string" => 1}, HEADER, @validator_option)
+        operation_object.validate_request_params({}, {}, {"string" => 1}, HEADER, @validator_option)
       }
 
       assert_match(/expected string, but received Integer: 1/i, e.message)
@@ -63,10 +66,10 @@ describe Committee::SchemaValidator::OpenAPI3::OperationWrapper do
 
     it 'support put method' do
       @method = "put"
-      operation_object.validate_request_params({"string" => "str"}, HEADER, @validator_option)
+      operation_object.validate_request_params({}, {}, {"string" => "str"}, HEADER, @validator_option)
 
       e = assert_raises(Committee::InvalidRequest) {
-        operation_object.validate_request_params({"string" => 1}, HEADER, @validator_option)
+        operation_object.validate_request_params({}, {}, {"string" => 1}, HEADER, @validator_option)
       }
 
       assert_match(/expected string, but received Integer: 1/i, e.message)
@@ -75,10 +78,10 @@ describe Committee::SchemaValidator::OpenAPI3::OperationWrapper do
 
     it 'support patch method' do
       @method = "patch"
-      operation_object.validate_request_params({"integer" => 1}, HEADER, @validator_option)
+      operation_object.validate_request_params({}, {}, {"integer" => 1}, HEADER, @validator_option)
 
       e = assert_raises(Committee::InvalidRequest) {
-        operation_object.validate_request_params({"integer" => "str"}, HEADER, @validator_option)
+        operation_object.validate_request_params({}, {}, {"integer" => "str"}, HEADER, @validator_option)
       }
 
       assert_match(/expected integer, but received String: "str"/i, e.message)
@@ -86,7 +89,7 @@ describe Committee::SchemaValidator::OpenAPI3::OperationWrapper do
     end
 
     it 'unknown param' do
-      operation_object.validate_request_params({"unknown" => 1}, HEADER, @validator_option)
+      operation_object.validate_request_params({}, {}, {"unknown" => 1}, HEADER, @validator_option)
     end
 
     describe 'support get method' do
@@ -96,13 +99,17 @@ describe Committee::SchemaValidator::OpenAPI3::OperationWrapper do
 
       it 'correct' do
         operation_object.validate_request_params(
+            {},
             {"query_string" => "query", "query_integer_list" => [1, 2]},
+            {},
             HEADER,
             @validator_option
         )
 
         operation_object.validate_request_params(
+            {},
             {"query_string" => "query", "query_integer_list" => [1, 2], "optional_integer" => 1},
+            {},
             HEADER,
             @validator_option
         )
@@ -112,7 +119,7 @@ describe Committee::SchemaValidator::OpenAPI3::OperationWrapper do
 
       it 'not exist required' do
         e = assert_raises(Committee::InvalidRequest) {
-          operation_object.validate_request_params({"query_integer_list" => [1, 2]}, HEADER, @validator_option)
+          operation_object.validate_request_params({}, {"query_integer_list" => [1, 2]}, {}, HEADER, @validator_option)
         }
 
         assert_match(/missing required parameters: query_string/i, e.message)
@@ -122,7 +129,9 @@ describe Committee::SchemaValidator::OpenAPI3::OperationWrapper do
       it 'invalid type' do
         e = assert_raises(Committee::InvalidRequest) {
           operation_object.validate_request_params(
+              {},
               {"query_string" => 1, "query_integer_list" => [1, 2], "optional_integer" => 1},
+              {},
               HEADER,
               @validator_option
           )
@@ -140,14 +149,14 @@ describe Committee::SchemaValidator::OpenAPI3::OperationWrapper do
       end
 
       it 'correct' do
-        operation_object.validate_request_params({"limit" => "1"}, HEADER, @validator_option)
+        operation_object.validate_request_params({}, {"limit" => "1"}, {}, HEADER, @validator_option)
 
         assert true
       end
 
       it 'invalid type' do
         e = assert_raises(Committee::InvalidRequest) {
-          operation_object.validate_request_params({"limit" => "a"}, HEADER, @validator_option)
+          operation_object.validate_request_params({}, {"limit" => "a"}, {}, HEADER, @validator_option)
         }
 
         assert_match(/expected integer, but received String: "a"/i, e.message)
@@ -162,14 +171,14 @@ describe Committee::SchemaValidator::OpenAPI3::OperationWrapper do
       end
 
       it 'correct' do
-        operation_object.validate_request_params({"limit" => "1"}, HEADER, @validator_option)
+        operation_object.validate_request_params({}, {"limit" => "1"}, {}, HEADER, @validator_option)
 
         assert true
       end
 
       it 'invalid type' do
         e = assert_raises(Committee::InvalidRequest) {
-          operation_object.validate_request_params({"limit" => "a"}, HEADER, @validator_option)
+          operation_object.validate_request_params({}, {"limit" => "a"}, {}, HEADER, @validator_option)
         }
 
         assert_match(/expected integer, but received String: "a"/i, e.message)
@@ -179,10 +188,10 @@ describe Committee::SchemaValidator::OpenAPI3::OperationWrapper do
 
     it 'support options method' do
       @method = "options"
-      operation_object.validate_request_params({"integer" => 1}, HEADER, @validator_option)
+      operation_object.validate_request_params({}, {}, {"integer" => 1}, HEADER, @validator_option)
 
       e = assert_raises(Committee::InvalidRequest) {
-        operation_object.validate_request_params({"integer" => "str"}, HEADER, @validator_option)
+        operation_object.validate_request_params({}, {}, {"integer" => "str"}, HEADER, @validator_option)
       }
 
       assert_match(/expected integer, but received String: "str"/i, e.message)

--- a/test/schema_validator/open_api_3/request_validator_test.rb
+++ b/test/schema_validator/open_api_3/request_validator_test.rb
@@ -71,6 +71,16 @@ describe Committee::SchemaValidator::OpenAPI3::RequestValidator do
       assert_equal 200, last_response.status
     end
 
+    it "does not mix up parameters and requestBody" do
+      @app = new_rack_app(check_content_type: true, schema: open_api_3_schema)
+      params = {
+          "last_name" => "Skywalker"
+      }
+      header "Content-Type", "application/json"
+      post "/additional_properties?first_name=Luke", JSON.generate(params)
+      assert_equal 200, last_response.status
+    end
+
     def new_rack_app(options = {})
       # TODO: delete when 5.0.0 released because default value changed
       options[:parse_response_by_content_type] = true if options[:parse_response_by_content_type] == nil


### PR DESCRIPTION
OpenAPI specifies 3 different types of parameters, let's validate them separately.